### PR TITLE
interest calculation is correct now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,11 @@ sqlc:
 test:
 	DB_SOURCE=${DB_SOURCE_TEST} go test -v -cover ./...
 
+store-test:
+	DB_SOURCE=${DB_SOURCE_TEST}	go test -tags=storetest -v ./db/sqlc
+
+handler-test:
+	DB_SOURCE=${DB_SOURCE_TEST}	go test -tags=handlertest -v ./api
+
 server:
 	go run cmd/main.go

--- a/api/handler_db_test.go
+++ b/api/handler_db_test.go
@@ -16,7 +16,7 @@ func TestMain(m *testing.M) {
 	testStore = sqlc.NewStore(util.TestDB)
 
 	code := m.Run()
-	//util.CleanupTestDB()
+	util.CleanupTestDB()
 
 	os.Exit(code)
 }

--- a/api/server.go
+++ b/api/server.go
@@ -25,6 +25,7 @@ func NewServer(store *sqlc.Store) *Server {
 		MaxAge:           12 * time.Hour,
 	}))
 
+	// account related routes (login, signup, fetch)
 	router.POST("/accounts", server.createAccount)
 	router.POST("/accounts/login", server.loginAccount)
 	router.GET("/accounts/:id", server.getAccount)
@@ -33,7 +34,7 @@ func NewServer(store *sqlc.Store) *Server {
 	// referral_Code feature routes
 	router.POST("/referral/account/:account", server.createReferral)
 	router.POST("/referral/code/:code", server.useReferralCode)
-	router.POST("referral/calculate/:account", server.calculateInterest)
+	router.GET("referral/calculate/:account", server.calculateInterest)
 	router.GET("/referral-codes", server.getReferralCodesForAccount)
 
 	server.router = router

--- a/db/sqlc/store_test.go
+++ b/db/sqlc/store_test.go
@@ -230,9 +230,17 @@ func TestUseReferralCodeTx(t *testing.T) {
 			expectedExtraInterest = 10.0
 		}
 
-		require.Equal(t, expectedExtraInterest, account.ExtraInterest.Float64)
-		require.NotZero(t, account.ExtraInterestStartDate)
-		require.Equal(t, int32(9), account.ExtraInterestDuration)
+		if expectedExtraInterest == 0 {
+			require.Equal(t, expectedExtraInterest, account.ExtraInterest.Float64)
+			require.Equal(t, int32(9), account.ExtraInterestDuration)
+		}
+
+		if referralCount != 0 {
+			require.Equal(t, expectedExtraInterest, account.ExtraInterest.Float64)
+			require.NotZero(t, account.ExtraInterestStartDate)
+			require.Equal(t, int32(9), account.ExtraInterestDuration)
+		}
+
 	}
 }
 


### PR DESCRIPTION
- User can create account just with name, email and a referral code if available
- User who creates account with referral code with get an 1000 yen balance and the user who created and provided the code will get 1% of extra interest
- A user can create a code
- A code cannot be used twice
- User can check all the used and unused codes
- User can directly copy the code by clicking or tapping on it
- Test written for every feature and tested in local development and in GitHub actions as well
- Interest Calculation logic is similar to the campaign logic of bank